### PR TITLE
Add support for more than 3 subnets

### DIFF
--- a/.github/scripts/validate-deploy.sh
+++ b/.github/scripts/validate-deploy.sh
@@ -39,6 +39,7 @@ if ! ibmcloud is vpc "${VPC_ID}"; then
 fi
 
 echo "Retrieving VPC subnets for VPC: ${VPC_NAME}"
+ibmcloud is subnets | grep "${VPC_NAME}"
 SUBNETS=$(ibmcloud is subnets | grep "${VPC_NAME}")
 
 if [[ -z "${SUBNETS}" ]]; then

--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,8 @@ provider "ibm" {
 }
 
 locals {
-  zone_ids         = range(1, var.subnet_count + 1)
-  vpc_zone_names   = [ for id in local.zone_ids: "${var.region}-${id}" ]
+  zone_ids         = range(0, var.subnet_count)
+  vpc_zone_names   = [ for index in local.zone_ids: "${var.region}-${(index % 3) + 1}" ]
   prefix_name      = var.name_prefix != "" ? var.name_prefix : var.resource_group_name
   vpc_name         = lower(replace(var.name != "" ? var.name : "${local.prefix_name}-vpc", "_", "-"))
   vpc_id           = ibm_is_vpc.vpc.id

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,7 @@
 provider "ibm" {
-  generation = 2
-  version = ">= 1.8.1"
-  region = var.region
-}
-provider "null" {
-}
-provider "local" {
+  generation       = 2
+  region           = var.region
+  ibmcloud_api_key = var.ibmcloud_api_key
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -5,13 +5,14 @@ provider "ibm" {
 }
 
 locals {
-  zone_ids         = range(0, var.subnet_count)
-  vpc_zone_names   = [ for index in local.zone_ids: "${var.region}-${(index % 3) + 1}" ]
+  zone_count       = 3
+  zone_ids         = range(var.subnet_count)
+  vpc_zone_names   = [ for index in local.zone_ids: "${var.region}-${(index % local.zone_count) + 1}" ]
   prefix_name      = var.name_prefix != "" ? var.name_prefix : var.resource_group_name
   vpc_name         = lower(replace(var.name != "" ? var.name : "${local.prefix_name}-vpc", "_", "-"))
   vpc_id           = ibm_is_vpc.vpc.id
   subnet_ids       = ibm_is_subnet.vpc_subnet[*].id
-  gateway_ids      = var.public_gateway ? ibm_is_public_gateway.vpc_gateway[*].id : [ for val in local.zone_ids: "" ]
+  gateway_ids      = var.public_gateway ? ibm_is_public_gateway.vpc_gateway[*].id : [ for val in range(local.zone_count): "" ]
   security_group   = ibm_is_vpc.vpc.default_security_group
   ipv4_cidr_blocks = ibm_is_subnet.vpc_subnet[*].ipv4_cidr_block
 }
@@ -26,7 +27,7 @@ resource ibm_is_vpc vpc {
 }
 
 resource ibm_is_public_gateway vpc_gateway {
-  count = var.public_gateway ? var.subnet_count : 0
+  count = var.public_gateway ? min(local.zone_count, var.subnet_count) : 0
 
   name           = "${local.vpc_name}-gateway-${format("%02s", count.index)}"
   vpc            = local.vpc_id
@@ -66,7 +67,7 @@ resource ibm_is_subnet vpc_subnet {
   name                     = "${local.vpc_name}-subnet-${format("%02s", count.index)}"
   zone                     = local.vpc_zone_names[count.index]
   vpc                      = local.vpc_id
-  public_gateway           = local.gateway_ids[count.index]
+  public_gateway           = local.gateway_ids[count.index % local.zone_count]
   total_ipv4_address_count = 256
   resource_group           = data.ibm_resource_group.resource_group.id
   network_acl              = ibm_is_network_acl.network_acl.id

--- a/test/stages/stage2-vpc.tf
+++ b/test/stages/stage2-vpc.tf
@@ -5,6 +5,6 @@ module "dev_vpc" {
   region              = var.region
   name_prefix         = var.name_prefix
   ibmcloud_api_key    = var.ibmcloud_api_key
-  subnet_count        = 1
+  subnet_count        = var.vpc_subnet_count
   public_gateway      = var.vpc_public_gateway == "true"
 }

--- a/test/stages/variables.tf
+++ b/test/stages/variables.tf
@@ -37,3 +37,9 @@ variable "vpc_public_gateway" {
   description = "Flag indicating the public gateway should be created"
   default     = "true"
 }
+
+variable "vpc_subnet_count" {
+  type        = number
+  description = "The number of subnets to create for the VPC instance"
+  default     = 6
+}


### PR DESCRIPTION
Previously the module would create zone names for each requested subnet. However, the regions only provide 3 zones -1, -2, -3. If the module requested more than 3 it would fail.

This change introduces a modulo function to determine the zone name based on the subnet number, e.g. zone-name = "${region}-${(subnet-index % 3) + 1}". That way, if you ask for 6 subnets you will get 2 in each zone. Also, you are only allowed one public gateway per zone so all the subnets in a particular zone use the same gateway.

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>