### PR TITLE
Sets IBM provider version dependency

### DIFF
--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ibm = {
       source = "ibm-cloud/ibm"
-      version = "1.20.0"
+      version = ">= 1.22.0"
     }
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     ibm = {
       source = "ibm-cloud/ibm"
-      version = ">= 1.17"
+      version = "1.20.0"
     }
   }
 }


### PR DESCRIPTION
- Updates required version to >= 1.22.0 to pick up `default_security_group_name` change (IBM-Cloud/terraform-provider-ibm#2216)

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>