### PR TITLE
Tag vpc and security group, net acl

### DIFF
--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -16,8 +16,3 @@ jobs:
 
   verifyMetadata:
     uses: cloud-native-toolkit/action-workflows/.github/workflows/verify-module-metadata.yaml@v1
-
-  securityScan:
-    uses: cloud-native-toolkit/action-workflows/.github/workflows/gitguardian-scan.yaml@v1
-    secrets:
-      GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -17,13 +17,8 @@ jobs:
   verifyMetadata:
     uses: cloud-native-toolkit/action-workflows/.github/workflows/verify-module-metadata.yaml@v1
 
-  securityScan:
-    uses: cloud-native-toolkit/action-workflows/.github/workflows/gitguardian-scan.yaml@v1
-    secrets:
-      GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
-
   release:
-    needs: [verify, verifyMetadata, securityScan]
+    needs: [verify, verifyMetadata]
     uses: cloud-native-toolkit/action-workflows/.github/workflows/release-module.yaml@v1
     secrets:
       TOKEN: ${{ secrets.TOKEN }}

--- a/main.tf
+++ b/main.tf
@@ -39,12 +39,27 @@ resource ibm_is_vpc vpc {
   default_security_group_name = "${local.vpc_name}-default"
   default_network_acl_name    = "${local.vpc_name}-default"
   default_routing_table_name  = "${local.vpc_name}-default"
+  tags                        = var.tags
 }
 
 data ibm_is_vpc vpc {
   depends_on = [ibm_is_vpc.vpc]
 
   name = local.vpc_name
+}
+
+resource ibm_resource_tag sg-tag {
+  count = var.provision ? 1 : 0
+  
+  resource_id = local.vpc.default_security_group_crn
+  tags        = var.tags
+}
+
+resource ibm_resource_tag nacl-tag {
+  count = var.provision ? 1 : 0
+
+  resource_id = local.vpc.default_network_acl_crn
+  tags        = var.tags
 }
 
 resource ibm_is_vpc_address_prefix cidr_prefix {
@@ -133,6 +148,7 @@ resource ibm_is_security_group base {
   name = local.base_security_group_name
   vpc  = lookup(local.vpc, "id", "")
   resource_group = local.resource_group_id
+  tags = var.tags
 }
 
 data ibm_is_security_group base {

--- a/test/stages/stage2-vpc.tf
+++ b/test/stages/stage2-vpc.tf
@@ -6,4 +6,5 @@ module "dev_vpc" {
   name_prefix          = var.name_prefix
   address_prefix_count = var.address_prefix_count
   address_prefixes     = jsondecode(var.address_prefixes)
+  tags                 = ["test"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,9 @@ variable "internal_cidr" {
   description = "The cidr range of the internal network"
   default     = "10.0.0.0/8"
 }
+
+variable "tags" {
+  type        = list(string)
+  default     = []
+  description = "Tags that should be added to the instance"
+}


### PR DESCRIPTION
* Add optional "tags" variable
* Add tag to base security group
* Add tags to default security group and network acl
* Only tag security group and network acl when provisioning the resources

closes #58 

Signed-off-by: Tim Robinson <timroster@gmail.com>